### PR TITLE
GitHub Actions修正&go.modのmodule記載ミスを修正

### DIFF
--- a/.github/workflows/notify_long_time_no_see.yml
+++ b/.github/workflows/notify_long_time_no_see.yml
@@ -7,7 +7,7 @@ on:
     - cron: 0 22 * * *
 
 jobs:
-  build:
+  notify:
     runs-on: ubuntu-latest
     env:
       TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
@@ -18,10 +18,10 @@ jobs:
         working-directory: tools/sincelastcommit
 
     steps:
-      - name: setup go
-        uses: actions/setup-go@v2
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.16
+          go-version: go.mod
 
       - name: Git clone
         uses: actions/checkout@v3

--- a/tools/sincelastcommit/go.mod
+++ b/tools/sincelastcommit/go.mod
@@ -1,4 +1,4 @@
-module github.com/mom0tomo/hugo-pages/tools
+module github.com/mom0tomo/hugo-pages/tools/sincelastcommit
 
 go 1.18
 


### PR DESCRIPTION
- [GitHub Actions の setup-go や setup-node で指定されるバージョンを go.mod や .node-version から取ってくる](https://blog.stenyan.jp/entry/2022/08/10/181302)
- moduleのパスが誤っていたので修正